### PR TITLE
Change in runtime loop:

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ TODO:
 - ./src/Compiler.cpp:67:  // TODO: Maybe include RDI and RAX
 - ./src/Compiler.cpp:71:  // TODO: fill avail regs and xregs with all registers
 - ./src/Interpreter.cpp:384:      // TODO: Make Long/Double constants more general
+- ./src/TraceRecorder.cpp:8:  // TODO: Maybe try handling this in a more pretty way
 - ./src/RunTime.cpp:8:  // TODO: Either move this functionality to Compiler or remove
-- ./src/RunTime.cpp:81:  // TODO: Standardize exception handing.
+- ./src/RunTime.cpp:83:  // TODO: Standardize exception handing.
 
 Created by Simon Kärrman och Jakob Erlandsson

--- a/include/TraceRecorder.hpp
+++ b/include/TraceRecorder.hpp
@@ -27,7 +27,7 @@ class TraceRecorder {
   void initRecording(ProgramCounter);
   void initRecording(ProgramCounter, ProgramCounter);
   Recording getRecording();
-  bool record(ProgramCounter, ByteCodeInstruction);
+  void record(ProgramCounter, ByteCodeInstruction);
 
  private:
   ProgramCounter traceStart;


### PR DESCRIPTION
- Removed a misplaced if statement
- Handle the case when a return statement becomes hot (happens in recursive factorial)
- Readded the isRecording check before initalizing "regular" recording, otherwise will side exit recording never work

Next step is to be able to comlile side exit traces.